### PR TITLE
Revert "Fix rspec eventually bug"

### DIFF
--- a/lib/dill/checkpoint.rb
+++ b/lib/dill/checkpoint.rb
@@ -13,10 +13,6 @@ module Dill
 
     self.rescuable_errors = [StandardError]
 
-    if defined?(RSpec::Expectations)
-      self.rescuable_errors << RSpec::Expectations::ExpectationNotMetError
-    end
-
     class Timer
       class Frozen < StandardError; end
 


### PR DESCRIPTION
RSpec::Expectations not defined when Dill loads.