### PR TITLE
Check if RSpec is defined, not RSpec::Expectations

### DIFF
--- a/lib/dill/checkpoint.rb
+++ b/lib/dill/checkpoint.rb
@@ -13,7 +13,8 @@ module Dill
 
     self.rescuable_errors = [StandardError]
 
-    if defined?(RSpec::Expectations)
+    if defined?(RSpec)
+      require 'rspec/expectations'
       self.rescuable_errors << RSpec::Expectations::ExpectationNotMetError
     end
 


### PR DESCRIPTION
RSpec::Expectations is not defined, but RSpec is. Once RSpec is defined, we can load `rspec/expectations`.